### PR TITLE
Change dependency from uglify-es to terser

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var UglifyJS = require("uglify-es");
+var UglifyJS = require("terser");
 var loaderUtils = require('loader-utils');
 var sourceMap = require('source-map');
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   "dependencies": {
     "loader-utils": "^1.0.2",
     "source-map": "^0.5.6",
-    "uglify-es": "^3.3.9"
+    "terser": "^3.10.11"
   }
 }


### PR DESCRIPTION
uglify-es is [no longer maintained](https://github.com/mishoo/UglifyJS2/issues/3156#issuecomment-392943058).

This PR updates dependency to [terser](https://github.com/terser-js/terser) as suggested by @fabiosantoscode 

closes #1 